### PR TITLE
Update constants.py

### DIFF
--- a/litecoinutils/constants.py
+++ b/litecoinutils/constants.py
@@ -25,9 +25,9 @@ NETWORK_P2PKH_PREFIXES = { 'mainnet': b'\x30',
                            'testnet': b'\x6f',
                            'regtest': b'\x6f' }
 
-NETWORK_P2SH_PREFIXES = { 'mainnet': b'\x05',
-                          'testnet': b'\xc4',
-                          'regtest': b'\xc4' }
+NETWORK_P2SH_PREFIXES = { 'mainnet': b'\x32',
+                          'testnet': b'\x3A',
+                          'regtest': b'\x3A' }
 
 NETWORK_SEGWIT_PREFIXES = { 'mainnet' : 'ltc',
                             'testnet' : 'tltc',


### PR DESCRIPTION
# Update the prefixes for P2SH mainnet and testnet

Noticed that you stopped the maintaining for Litecoin, but still it's useful repo and to force examples work - prefixes should be correct 😉 